### PR TITLE
Implement trading data export system to text file

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,30 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem('marketplace_posts', JSON.stringify(posts));
   }
 
+  // Save posts to text file (data.txt)
+  function savePostsToTextFile(posts) {
+    let textContent = '=== MARKETPLACE TRADING DATA ===\n';
+    textContent += `Generated: ${new Date().toLocaleString('ja-JP')}\n`;
+    textContent += `Total Items: ${posts.length}\n\n`;
+    
+    posts.forEach((post, index) => {
+      textContent += `[${index + 1}] ${post.title}\n`;
+      textContent += `Price: ¥${Number(post.price).toLocaleString()}\n`;
+      textContent += `Description: ${post.description}\n`;
+      textContent += '---\n\n';
+    });
+    
+    const blob = new Blob([textContent], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'data.txt';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
   // Insert sample data if needed
   function insertSampleIfNeeded() {
     if (!localStorage.getItem('marketplace_posts')) {
@@ -76,6 +100,12 @@ document.addEventListener('DOMContentLoaded', () => {
     savePosts(posts);
     renderPosts();
     postForm.reset();
+  });
+
+  // Export button functionality
+  document.getElementById('export-btn').addEventListener('click', () => {
+    const posts = getPosts();
+    savePostsToTextFile(posts);
   });
 
   insertSampleIfNeeded();

--- a/index.html
+++ b/index.html
@@ -21,7 +21,10 @@
       </form>
     </section>
     <section id="marketplace-list">
-      <h2>Listings</h2>
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+        <h2>Listings</h2>
+        <button id="export-btn" style="background: #28a745; color: white; border: none; border-radius: 8px; padding: 0.5rem 1rem; cursor: pointer; font-size: 0.9rem;">Export Data</button>
+      </div>
       <ul id="posts"></ul>
     </section>
   </main>

--- a/sample_data.txt
+++ b/sample_data.txt
@@ -1,0 +1,18 @@
+=== MARKETPLACE TRADING DATA ===
+Generated: 2025/5/26 11:57:00
+Total Items: 3
+
+[1] iPhone 13 Pro 256GB
+Price: ¥85,000
+Description: Excellent condition, all accessories included. SIM-free.
+---
+
+[2] MacBook Air M1
+Price: ¥95,000
+Description: 2021 model, battery in good health. Box included.
+---
+
+[3] Nintendo Switch
+Price: ¥25,000
+Description: Fully functional, includes Joy-Con grip.
+---


### PR DESCRIPTION
Implement trading data export system to text file

## Summary
- Add savePostsToTextFile() function to format and export data to data.txt
- Add Export Data button to UI for manual data export
- Include proper Japanese formatting and timestamps
- Sample data format included in sample_data.txt

Fixes #2

Generated with [Claude Code](https://claude.ai/code)